### PR TITLE
Fix karaoke playback synchronization

### DIFF
--- a/console.html
+++ b/console.html
@@ -44,7 +44,7 @@
   <div class="musica-atual">
     <h2>🎶 Tocando Agora</h2>
     <p id="musicaAtual">Carregando...</p>
-    <button id="tocarBtn">▶️ Tocar próxima da fila</button>
+    <button id="tocarBtn">▶️ Pular / Próxima</button>
   </div>
 
   <div class="fila">
@@ -57,7 +57,7 @@
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
     import {
       getFirestore, doc, getDoc, setDoc, onSnapshot, getDocs,
-      query, where, collection
+      query, where, collection, arrayUnion, orderBy
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     const firebaseConfig = {
@@ -111,34 +111,96 @@
       });
     }
 
+  async function finalizarMusicaAtual() {
+      const musicaSnap = await getDoc(doc(db, "sistema", "musicaAtual"));
+      const musica = musicaSnap.data();
+      if (!musica || !musica.youtubeId) return;
+
+      await setDoc(doc(db, "sistema", "historico"),
+        { lista: arrayUnion({ ...musica, finalizadaEm: new Date() }) },
+        { merge: true }
+      );
+
+      const filaSnap = await getDoc(doc(db, "sistema", "filaOrdenada"));
+      let filaAtual = filaSnap.data()?.fila || [];
+      if (filaAtual.length && filaAtual[0].youtubeId === musica.youtubeId) {
+        filaAtual.shift();
+        await setDoc(doc(db, "sistema", "filaOrdenada"), { fila: filaAtual });
+      }
+
+      if (musica.mesaId) {
+        const q = query(
+          collection(db, "mesas", musica.mesaId, "suasMusicas"),
+          where("youtubeId", "==", musica.youtubeId)
+        );
+        const docs = await getDocs(q);
+        docs.forEach(d => d.ref.delete());
+      }
+
+      await atualizarFilaGlobal();
+
+      if (filaAtual.length) {
+        await setDoc(doc(db, "sistema", "musicaAtual"), filaAtual[0]);
+      } else {
+        await setDoc(doc(db, "sistema", "musicaAtual"), {});
+      }
+    }
+
+    async function atualizarFilaGlobal() {
+      const mesasSnap = await getDocs(collection(db, "mesas"));
+      const mesas = [];
+      for (const mesa of mesasSnap.docs) {
+        const musicasSnap = await getDocs(query(
+          collection(db, "mesas", mesa.id, "suasMusicas"),
+          orderBy("dataHora")
+        ));
+        mesas.push({
+          mesaId: mesa.id,
+          musicas: musicasSnap.docs.map(d => d.data())
+        });
+      }
+
+      let fila = [];
+      let idx = 0;
+      let restante = true;
+      while (restante) {
+        restante = false;
+        for (const m of mesas) {
+          for (let i = 0; i < 2; i++) {
+            const musica = m.musicas[idx + i];
+            if (musica) {
+              fila.push({ mesaId: m.mesaId, ...musica });
+              restante = true;
+            }
+          }
+        }
+        idx += 2;
+      }
+
+      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila });
+    }
+
     // ▶️ Tocar a próxima
     async function tocarProxima() {
       if (!filaRodizio.length) {
         alert("Fila vazia!");
         return;
       }
-
-      const proxima = filaRodizio.shift();
-
-      // Salvar como atual
-      await setDoc(doc(db, "sistema", "musicaAtual"), proxima);
-
-      // Remover da coleção da mesa
-      const snap = await getDocs(query(
-        collection(db, "mesas", proxima.mesaId, "suasMusicas"),
-        where("youtubeId", "==", proxima.youtubeId)
-      ));
-      snap.forEach(doc => doc.ref.delete());
-
-      // Atualizar fila no Firestore
-      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila: filaRodizio });
+      const atualSnap = await getDoc(doc(db, "sistema", "musicaAtual"));
+      const atual = atualSnap.data();
+      if (!atual || !atual.youtubeId) {
+        await setDoc(doc(db, "sistema", "musicaAtual"), filaRodizio[0]);
+      } else {
+        await finalizarMusicaAtual();
+      }
     }
 
     tocarBtn.addEventListener("click", tocarProxima);
 
     // 🚀 Inicialização
-    monitorarFila();
-    monitorarMusicaAtual();
+      monitorarFila();
+      monitorarMusicaAtual();
+      atualizarFilaGlobal();
   </script>
 </body>
 </html>

--- a/karaoke-tv.html
+++ b/karaoke-tv.html
@@ -45,7 +45,8 @@
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
     import {
-      getFirestore, doc, onSnapshot
+      getFirestore, doc, onSnapshot, getDoc, setDoc, collection,
+      query, where, getDocs, arrayUnion, orderBy
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // Firebase config
@@ -61,8 +62,14 @@
     const app = initializeApp(firebaseConfig);
     const db = getFirestore(app);
 
+    const filaRef = doc(db, "sistema", "filaOrdenada");
+    const musicaAtualRef = doc(db, "sistema", "musicaAtual");
+    const historicoRef = doc(db, "sistema", "historico");
+
     let player;
     let videoAtual = "";
+    let fila = [];
+    let musicaAtualData = null;
 
     // Aguarda o carregamento da API do YouTube
     window.onYouTubeIframeAPIReady = () => {
@@ -93,27 +100,115 @@
       }
     }
 
+    async function finalizarMusica() {
+      const snapAtual = await getDoc(musicaAtualRef);
+      const musica = snapAtual.data();
+      if (!musica || !musica.youtubeId) return;
+
+      await setDoc(historicoRef,
+        { lista: arrayUnion({ ...musica, finalizadaEm: new Date() }) },
+        { merge: true }
+      );
+
+      const filaSnap = await getDoc(filaRef);
+      let filaAtual = filaSnap.data()?.fila || [];
+      if (filaAtual.length && filaAtual[0].youtubeId === musica.youtubeId) {
+        filaAtual.shift();
+        await setDoc(filaRef, { fila: filaAtual });
+      }
+
+      if (musica.mesaId) {
+        const q = query(
+          collection(db, "mesas", musica.mesaId, "suasMusicas"),
+          where("youtubeId", "==", musica.youtubeId)
+        );
+        const docs = await getDocs(q);
+        docs.forEach(d => d.ref.delete());
+      }
+
+      await atualizarFilaGlobal();
+
+      if (filaAtual.length) {
+        await setDoc(musicaAtualRef, filaAtual[0]);
+      } else {
+        await setDoc(musicaAtualRef, {});
+      }
+    }
+
+    async function atualizarFilaGlobal() {
+      const mesasSnap = await getDocs(collection(db, "mesas"));
+      const mesas = [];
+      for (const mesa of mesasSnap.docs) {
+        const musicasSnap = await getDocs(query(
+          collection(db, "mesas", mesa.id, "suasMusicas"),
+          orderBy("dataHora")
+        ));
+        mesas.push({
+          mesaId: mesa.id,
+          musicas: musicasSnap.docs.map(d => d.data())
+        });
+      }
+
+      let fila = [];
+      let idx = 0;
+      let restante = true;
+      while (restante) {
+        restante = false;
+        for (const m of mesas) {
+          for (let i = 0; i < 2; i++) {
+            const musica = m.musicas[idx + i];
+            if (musica) {
+              fila.push({ mesaId: m.mesaId, ...musica });
+              restante = true;
+            }
+          }
+        }
+        idx += 2;
+      }
+
+      await setDoc(filaRef, { fila });
+    }
+
     function onPlayerStateChange(event) {
       if (event.data === YT.PlayerState.ENDED) {
         document.getElementById("info").textContent = "🎵 Música finalizada. Aguardando próxima...";
+        finalizarMusica();
       }
     }
 
     function onPlayerError(event) {
       console.error("Erro ao tocar vídeo:", event.data);
       document.getElementById("info").textContent = "⚠️ Erro no vídeo. Pulando...";
+      finalizarMusica();
     }
 
-    // Monitora música atual
-    const musicaAtualRef = doc(db, "sistema", "musicaAtual");
-    onSnapshot(musicaAtualRef, (docSnap) => {
-      const data = docSnap.data();
-      if (data?.youtubeId && data.youtubeId !== videoAtual) {
-        videoAtual = data.youtubeId;
-        tocarVideo(data.youtubeId);
-        document.getElementById("info").textContent = `🎶 ${data.titulo} (Mesa ${data.mesaId})`;
+    // Observa a fila
+    onSnapshot(filaRef, (snap) => {
+      fila = snap.data()?.fila || [];
+      if (!musicaAtualData?.youtubeId && fila.length) {
+        setDoc(musicaAtualRef, fila[0]);
       }
     });
+
+    // Monitora música atual
+    onSnapshot(musicaAtualRef, (docSnap) => {
+      musicaAtualData = docSnap.data();
+      if (musicaAtualData?.youtubeId) {
+        if (musicaAtualData.youtubeId !== videoAtual) {
+          videoAtual = musicaAtualData.youtubeId;
+          tocarVideo(videoAtual);
+        }
+        document.getElementById("info").textContent = `🎶 ${musicaAtualData.titulo} (Mesa ${musicaAtualData.mesaId})`;
+      } else {
+        document.getElementById("info").textContent = "Aguardando música...";
+        videoAtual = "";
+        if (fila.length) {
+          setDoc(musicaAtualRef, fila[0]);
+        }
+      }
+    });
+
+    atualizarFilaGlobal();
   </script>
 </body>
 </html>

--- a/karaoke.html
+++ b/karaoke.html
@@ -60,7 +60,8 @@
   <!-- Firebase Modular -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getFirestore, collection, doc, query, orderBy, onSnapshot, addDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+    import { getFirestore, collection, doc, query, orderBy, onSnapshot,
+      addDoc, deleteDoc, getDocs, setDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // Configuração Firebase
     const firebaseConfig = {
@@ -93,20 +94,64 @@
     onSnapshot(q, (snapshot) => {
       suasMusicas = [];
       lista.innerHTML = "";
-      snapshot.forEach(doc => {
-        const m = doc.data();
+      snapshot.forEach(docSnap => {
+        const m = { id: docSnap.id, ...docSnap.data() };
         suasMusicas.push(m);
         const li = document.createElement("li");
         li.textContent = m.titulo;
+        const del = document.createElement("button");
+        del.textContent = "Excluir";
+        del.style.marginLeft = "10px";
+        del.addEventListener("click", () => excluirMusica(m.id));
+        li.appendChild(del);
         lista.appendChild(li);
       });
-      btn.disabled = suasMusicas.length >= 2;
+      btn.disabled = suasMusicas.length >= 4;
     });
+
+    async function excluirMusica(id) {
+      await deleteDoc(doc(db, "mesas", mesaId, "suasMusicas", id));
+      atualizarFilaGlobal();
+    }
+
+    async function atualizarFilaGlobal() {
+      const mesasSnap = await getDocs(collection(db, "mesas"));
+      const mesas = [];
+      for (const mesa of mesasSnap.docs) {
+        const musicasSnap = await getDocs(query(
+          collection(db, "mesas", mesa.id, "suasMusicas"),
+          orderBy("dataHora")
+        ));
+        mesas.push({
+          mesaId: mesa.id,
+          musicas: musicasSnap.docs.map(d => d.data())
+        });
+      }
+
+      let fila = [];
+      let idx = 0;
+      let restante = true;
+      while (restante) {
+        restante = false;
+        for (const m of mesas) {
+          for (let i = 0; i < 2; i++) {
+            const musica = m.musicas[idx + i];
+            if (musica) {
+              fila.push({ mesaId: m.mesaId, ...musica });
+              restante = true;
+            }
+          }
+        }
+        idx += 2;
+      }
+
+      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila });
+    }
 
     // Clique no botão "Adicionar Música"
     btn.addEventListener("click", async () => {
       const nome = buscaInput.value.trim();
-      if (!nome || suasMusicas.length >= 2) return;
+      if (!nome || suasMusicas.length >= 4) return;
 
       btn.disabled = true;
       btn.textContent = "Buscando...";
@@ -127,6 +172,7 @@
           titulo: json.titulo,
           dataHora: new Date()
         });
+        atualizarFilaGlobal();
 
         buscaInput.value = "";
       } catch (err) {
@@ -140,7 +186,7 @@
 
     // Ativar botão quando digitar algo
     buscaInput.addEventListener("input", () => {
-      btn.disabled = !buscaInput.value.trim() || suasMusicas.length >= 2;
+      btn.disabled = !buscaInput.value.trim() || suasMusicas.length >= 4;
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update karaoke TV logic to automatically advance queue and handle errors
- sync console with TV and allow skipping to the next song
- add deletion for table songs and limit to 4 selections per table
- enforce queue rotation of two songs per table

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8c0a370832a92c80c00d694ccfe