### PR TITLE
Fix YouTube search filtering

### DIFF
--- a/karaoke.html
+++ b/karaoke.html
@@ -115,7 +115,7 @@
         const res = await fetch(`/api/buscar-video?q=${encodeURIComponent(nome)}`);
         const json = await res.json();
 
-        if (!json.youtubeId) {
+        if (!json.videoId) {
           alert("Nenhum vídeo válido encontrado.");
           btn.disabled = false;
           btn.textContent = "Adicionar Música";
@@ -123,7 +123,7 @@
         }
 
         await addDoc(mesaRef, {
-          youtubeId: json.youtubeId,
+          youtubeId: json.videoId,
           titulo: json.titulo,
           dataHora: new Date()
         });


### PR DESCRIPTION
## Summary
- update YouTube search API to filter out private, non-embeddable, and live videos
- order by view count and return relevant fields
- adapt client to expect `videoId` from API when saving songs

## Testing
- `node -e "import('./api/buscar-video.js').then(()=>console.log('ok')).catch(console.error)"`
- `node - <<'NODE'
import handler from './api/buscar-video.js';
const req = { query: { q: 'Bohemian Rhapsody' } };
const res = { status(c){this.statusCode=c;return this;}, json(o){console.log('response', this.statusCode||200, o);} };
handler(req,res).catch(console.error);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6859fd3d5554832aa45d5940deb0dbea