### PR TITLE
Implement YouTube player fix and queue removal actions

### DIFF
--- a/console.html
+++ b/console.html
@@ -93,7 +93,14 @@
       filaEl.innerHTML = "";
       filaRodizio.forEach((m, i) => {
         const li = document.createElement("li");
-        li.textContent = `${i + 1}. ${m.titulo} (mesa ${m.mesaId})`;
+        const span = document.createElement("span");
+        span.textContent = `${i + 1}. ${m.titulo} (mesa ${m.mesaId})`;
+        const btn = document.createElement("button");
+        btn.textContent = "🗑️ Remover";
+        btn.style.marginLeft = "10px";
+        btn.addEventListener("click", () => removerDaFila(i, m));
+        li.appendChild(span);
+        li.appendChild(btn);
         filaEl.appendChild(li);
       });
     }
@@ -141,6 +148,22 @@
         await setDoc(doc(db, "sistema", "musicaAtual"), filaAtual[0]);
       } else {
         await setDoc(doc(db, "sistema", "musicaAtual"), {});
+      }
+    }
+
+    async function removerDaFila(index, musica) {
+      const filaSnap = await getDoc(doc(db, "sistema", "filaOrdenada"));
+      const filaAtual = filaSnap.data()?.fila || [];
+      filaAtual.splice(index, 1);
+      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila: filaAtual });
+
+      if (musica.mesaId) {
+        const q = query(
+          collection(db, "mesas", musica.mesaId, "suasMusicas"),
+          where("youtubeId", "==", musica.youtubeId)
+        );
+        const docs = await getDocs(q);
+        docs.forEach(d => d.ref.delete());
       }
     }
 

--- a/karaoke-tv.html
+++ b/karaoke-tv.html
@@ -71,34 +71,48 @@
     let fila = [];
     let musicaAtualData = null;
 
-    // Aguarda o carregamento da API do YouTube
-    window.onYouTubeIframeAPIReady = () => {
-      player = new YT.Player("player", {
-        height: "100%",
-        width: "100%",
-        videoId: "",
-        playerVars: {
-          autoplay: 1,
-          controls: 1,
-          modestbranding: 1,
-          rel: 0,
-          showinfo: 0
-        },
-        events: {
-          onReady: () => {
-            document.getElementById("info").textContent = "🎤 Pronto para tocar!";
+    function iniciarPlayer(videoId) {
+      if (!videoId) return;
+      const erro = localStorage.getItem("erroVideoId");
+      if (erro && erro === videoId) {
+        document.getElementById("info").textContent = "Erro ao carregar vídeo. Pulando...";
+        pularParaProximaMusica();
+        return;
+      }
+      localStorage.setItem("ultimoVideoIdTestado", videoId);
+      if (!player) {
+        player = new YT.Player("player", {
+          height: "100%",
+          width: "100%",
+          videoId,
+          playerVars: {
+            autoplay: 1,
+            controls: 1,
+            loop: 0,
+            modestbranding: 1
           },
-          onStateChange: onPlayerStateChange,
-          onError: onPlayerError
-        }
-      });
-    };
-
-    function tocarVideo(videoId) {
-      if (player && player.loadVideoById && videoId) {
+          events: {
+            onReady: (e) => {
+              localStorage.removeItem("erroVideoId");
+              e.target.playVideo();
+            },
+            onStateChange: onPlayerStateChange,
+            onError: onPlayerError
+          }
+        });
+      } else {
+        localStorage.removeItem("erroVideoId");
         player.loadVideoById(videoId);
+        player.playVideo();
       }
     }
+
+    // Aguarda o carregamento da API do YouTube
+    window.onYouTubeIframeAPIReady = () => {
+      if (musicaAtualData?.youtubeId) {
+        iniciarPlayer(musicaAtualData.youtubeId);
+      }
+    };
 
     async function finalizarMusica() {
       const snapAtual = await getDoc(musicaAtualRef);
@@ -133,6 +147,10 @@
       }
     }
 
+    async function pularParaProximaMusica() {
+      await finalizarMusica();
+    }
+
     function onPlayerStateChange(event) {
       if (event.data === YT.PlayerState.ENDED) {
         document.getElementById("info").textContent = "🎵 Música finalizada. Aguardando próxima...";
@@ -142,8 +160,9 @@
 
     function onPlayerError(event) {
       console.error("Erro ao tocar vídeo:", event.data);
-      document.getElementById("info").textContent = "⚠️ Erro no vídeo. Pulando...";
-      finalizarMusica();
+      localStorage.setItem("erroVideoId", videoAtual);
+      document.getElementById("info").textContent = "Erro ao carregar vídeo. Pulando...";
+      pularParaProximaMusica();
     }
 
     // Observa a fila
@@ -160,7 +179,7 @@
       if (musicaAtualData?.youtubeId) {
         if (musicaAtualData.youtubeId !== videoAtual) {
           videoAtual = musicaAtualData.youtubeId;
-          tocarVideo(videoAtual);
+          iniciarPlayer(videoAtual);
         }
         document.getElementById("info").textContent = `🎶 ${musicaAtualData.titulo} (Mesa ${musicaAtualData.mesaId})`;
       } else {

--- a/karaoke.html
+++ b/karaoke.html
@@ -60,7 +60,7 @@
   <!-- Firebase Modular -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getFirestore, collection, doc, query, orderBy, onSnapshot, addDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+    import { getFirestore, collection, doc, query, orderBy, onSnapshot, addDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // Configuração Firebase
     const firebaseConfig = {
@@ -93,11 +93,18 @@
     onSnapshot(q, (snapshot) => {
       suasMusicas = [];
       lista.innerHTML = "";
-      snapshot.forEach(doc => {
-        const m = doc.data();
+      snapshot.forEach(docSnap => {
+        const m = docSnap.data();
         suasMusicas.push(m);
         const li = document.createElement("li");
-        li.textContent = m.titulo;
+        const span = document.createElement("span");
+        span.textContent = m.titulo;
+        const removeBtn = document.createElement("button");
+        removeBtn.textContent = "❌";
+        removeBtn.style.marginLeft = "10px";
+        removeBtn.addEventListener("click", () => removerMusica(docSnap.id));
+        li.appendChild(span);
+        li.appendChild(removeBtn);
         lista.appendChild(li);
       });
       btn.disabled = suasMusicas.length >= 2;
@@ -142,6 +149,10 @@
     buscaInput.addEventListener("input", () => {
       btn.disabled = !buscaInput.value.trim() || suasMusicas.length >= 2;
     });
+
+    async function removerMusica(id) {
+      await deleteDoc(doc(db, "mesas", mesaId, "suasMusicas", id));
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create YouTube player only when a valid `musicaAtual` is available
- skip videos with previous errors and store the failing id locally
- allow queue removal from console and from table interface

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff0800ec832a9593b0e1221a60f3