### PR TITLE
Implement queue sync on song add/remove

### DIFF
--- a/console.html
+++ b/console.html
@@ -93,7 +93,14 @@
       filaEl.innerHTML = "";
       filaRodizio.forEach((m, i) => {
         const li = document.createElement("li");
-        li.textContent = `${i + 1}. ${m.titulo} (mesa ${m.mesaId})`;
+        const span = document.createElement("span");
+        span.textContent = `${i + 1}. ${m.nome} (mesa ${m.mesa})`;
+        const btn = document.createElement("button");
+        btn.textContent = "🗑️ Remover";
+        btn.style.marginLeft = "10px";
+        btn.addEventListener("click", () => removerDaFila(i, m));
+        li.appendChild(span);
+        li.appendChild(btn);
         filaEl.appendChild(li);
       });
     }
@@ -103,8 +110,8 @@
       const ref = doc(db, "sistema", "musicaAtual");
       onSnapshot(ref, (docSnap) => {
         const data = docSnap.data();
-        if (data?.titulo) {
-          musicaAtualEl.textContent = `${data.titulo} (mesa ${data.mesaId})`;
+        if (data?.nome) {
+          musicaAtualEl.textContent = `${data.nome} (mesa ${data.mesa})`;
         } else {
           musicaAtualEl.textContent = "Nenhuma música tocando.";
         }
@@ -128,9 +135,9 @@
         await setDoc(doc(db, "sistema", "filaOrdenada"), { fila: filaAtual });
       }
 
-      if (musica.mesaId) {
+      if (musica.mesa) {
         const q = query(
-          collection(db, "mesas", musica.mesaId, "suasMusicas"),
+          collection(db, "mesas", musica.mesa, "suasMusicas"),
           where("youtubeId", "==", musica.youtubeId)
         );
         const docs = await getDocs(q);
@@ -141,6 +148,22 @@
         await setDoc(doc(db, "sistema", "musicaAtual"), filaAtual[0]);
       } else {
         await setDoc(doc(db, "sistema", "musicaAtual"), {});
+      }
+    }
+
+    async function removerDaFila(index, musica) {
+      const filaSnap = await getDoc(doc(db, "sistema", "filaOrdenada"));
+      const filaAtual = filaSnap.data()?.fila || [];
+      filaAtual.splice(index, 1);
+      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila: filaAtual });
+
+      if (musica.mesa) {
+        const q = query(
+          collection(db, "mesas", musica.mesa, "suasMusicas"),
+          where("youtubeId", "==", musica.youtubeId)
+        );
+        const docs = await getDocs(q);
+        docs.forEach(d => d.ref.delete());
       }
     }
 

--- a/karaoke-tv.html
+++ b/karaoke-tv.html
@@ -71,34 +71,48 @@
     let fila = [];
     let musicaAtualData = null;
 
-    // Aguarda o carregamento da API do YouTube
-    window.onYouTubeIframeAPIReady = () => {
-      player = new YT.Player("player", {
-        height: "100%",
-        width: "100%",
-        videoId: "",
-        playerVars: {
-          autoplay: 1,
-          controls: 1,
-          modestbranding: 1,
-          rel: 0,
-          showinfo: 0
-        },
-        events: {
-          onReady: () => {
-            document.getElementById("info").textContent = "🎤 Pronto para tocar!";
+    function iniciarPlayer(videoId) {
+      if (!videoId) return;
+      const erro = localStorage.getItem("erroVideoId");
+      if (erro && erro === videoId) {
+        document.getElementById("info").textContent = "Erro ao carregar vídeo. Pulando...";
+        pularParaProximaMusica();
+        return;
+      }
+      localStorage.setItem("ultimoVideoIdTestado", videoId);
+      if (!player) {
+        player = new YT.Player("player", {
+          height: "100%",
+          width: "100%",
+          videoId,
+          playerVars: {
+            autoplay: 1,
+            controls: 1,
+            loop: 0,
+            modestbranding: 1
           },
-          onStateChange: onPlayerStateChange,
-          onError: onPlayerError
-        }
-      });
-    };
-
-    function tocarVideo(videoId) {
-      if (player && player.loadVideoById && videoId) {
+          events: {
+            onReady: (e) => {
+              localStorage.removeItem("erroVideoId");
+              e.target.playVideo();
+            },
+            onStateChange: onPlayerStateChange,
+            onError: onPlayerError
+          }
+        });
+      } else {
+        localStorage.removeItem("erroVideoId");
         player.loadVideoById(videoId);
+        player.playVideo();
       }
     }
+
+    // Aguarda o carregamento da API do YouTube
+    window.onYouTubeIframeAPIReady = () => {
+      if (musicaAtualData?.youtubeId) {
+        iniciarPlayer(musicaAtualData.youtubeId);
+      }
+    };
 
     async function finalizarMusica() {
       const snapAtual = await getDoc(musicaAtualRef);
@@ -117,9 +131,9 @@
         await setDoc(filaRef, { fila: filaAtual });
       }
 
-      if (musica.mesaId) {
+      if (musica.mesa) {
         const q = query(
-          collection(db, "mesas", musica.mesaId, "suasMusicas"),
+          collection(db, "mesas", musica.mesa, "suasMusicas"),
           where("youtubeId", "==", musica.youtubeId)
         );
         const docs = await getDocs(q);
@@ -133,6 +147,10 @@
       }
     }
 
+    async function pularParaProximaMusica() {
+      await finalizarMusica();
+    }
+
     function onPlayerStateChange(event) {
       if (event.data === YT.PlayerState.ENDED) {
         document.getElementById("info").textContent = "🎵 Música finalizada. Aguardando próxima...";
@@ -142,8 +160,9 @@
 
     function onPlayerError(event) {
       console.error("Erro ao tocar vídeo:", event.data);
-      document.getElementById("info").textContent = "⚠️ Erro no vídeo. Pulando...";
-      finalizarMusica();
+      localStorage.setItem("erroVideoId", videoAtual);
+      document.getElementById("info").textContent = "Erro ao carregar vídeo. Pulando...";
+      pularParaProximaMusica();
     }
 
     // Observa a fila
@@ -160,9 +179,9 @@
       if (musicaAtualData?.youtubeId) {
         if (musicaAtualData.youtubeId !== videoAtual) {
           videoAtual = musicaAtualData.youtubeId;
-          tocarVideo(videoAtual);
+          iniciarPlayer(videoAtual);
         }
-        document.getElementById("info").textContent = `🎶 ${musicaAtualData.titulo} (Mesa ${musicaAtualData.mesaId})`;
+        document.getElementById("info").textContent = `🎶 ${musicaAtualData.nome} (Mesa ${musicaAtualData.mesa})`;
       } else {
         document.getElementById("info").textContent = "Aguardando música...";
         videoAtual = "";

--- a/karaoke.html
+++ b/karaoke.html
@@ -60,7 +60,10 @@
   <!-- Firebase Modular -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-    import { getFirestore, collection, doc, query, orderBy, onSnapshot, addDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+    import {
+      getFirestore, collection, doc, query, orderBy, onSnapshot,
+      addDoc, deleteDoc, getDocs, setDoc, where
+    } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // Configuração Firebase
     const firebaseConfig = {
@@ -88,16 +91,23 @@
     let suasMusicas = [];
 
     const mesaRef = collection(db, "mesas", mesaId, "suasMusicas");
-    const q = query(mesaRef, orderBy("dataHora"));
+    const q = query(mesaRef, orderBy("horario"));
 
     onSnapshot(q, (snapshot) => {
       suasMusicas = [];
       lista.innerHTML = "";
-      snapshot.forEach(doc => {
-        const m = doc.data();
+      snapshot.forEach(docSnap => {
+        const m = docSnap.data();
         suasMusicas.push(m);
         const li = document.createElement("li");
-        li.textContent = m.titulo;
+        const span = document.createElement("span");
+        span.textContent = m.nome || m.titulo;
+        const removeBtn = document.createElement("button");
+        removeBtn.textContent = "❌";
+        removeBtn.style.marginLeft = "10px";
+        removeBtn.addEventListener("click", () => removerMusica(docSnap.id));
+        li.appendChild(span);
+        li.appendChild(removeBtn);
         lista.appendChild(li);
       });
       btn.disabled = suasMusicas.length >= 2;
@@ -122,11 +132,22 @@
           return;
         }
 
+        // Evita duplicatas na lista da mesa
+        const dup = await getDocs(query(mesaRef, where("youtubeId", "==", json.videoId)));
+        if (!dup.empty) {
+          alert("Essa música já está na fila da mesa.");
+          btn.disabled = false;
+          btn.textContent = "Adicionar Música";
+          return;
+        }
+
         await addDoc(mesaRef, {
           youtubeId: json.videoId,
-          titulo: json.titulo,
-          dataHora: new Date()
+          nome: json.titulo,
+          horario: new Date()
         });
+
+        await atualizarFilaGlobal();
 
         buscaInput.value = "";
       } catch (err) {
@@ -142,6 +163,40 @@
     buscaInput.addEventListener("input", () => {
       btn.disabled = !buscaInput.value.trim() || suasMusicas.length >= 2;
     });
+
+    async function removerMusica(id) {
+      await deleteDoc(doc(db, "mesas", mesaId, "suasMusicas", id));
+      await atualizarFilaGlobal();
+    }
+
+    async function atualizarFilaGlobal() {
+      const mesasSnap = await getDocs(collection(db, "mesas"));
+      const mesas = [];
+      for (const mesaDoc of mesasSnap.docs) {
+        const musicasSnap = await getDocs(query(
+          collection(db, "mesas", mesaDoc.id, "suasMusicas"),
+          orderBy("horario")
+        ));
+        const musicas = musicasSnap.docs.map(d => ({
+          id: d.id,
+          youtubeId: d.data().youtubeId,
+          nome: d.data().nome || d.data().titulo,
+          horario: d.data().horario || d.data().dataHora,
+          mesa: mesaDoc.id
+        }));
+        if (musicas.length) mesas.push({ mesaId: mesaDoc.id, musicas });
+      }
+      const fila = [];
+      for (let i = 0; i < 2; i++) {
+        mesas.forEach(m => {
+          if (m.musicas[i]) {
+            const { id, youtubeId, nome, horario } = m.musicas[i];
+            fila.push({ id, youtubeId, nome, horario, mesa: m.mesaId });
+          }
+        });
+      }
+      await setDoc(doc(db, "sistema", "filaOrdenada"), { fila });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update karaoke.html to push songs to global queue and prevent duplicates
- adjust rendering and data fields to `nome`, `mesa`, `horario`, and `id`
- sync queue in real time and show song removal buttons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff0800ec832a9593b0e1221a60f3